### PR TITLE
Update zkg.meta

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -2,5 +2,5 @@
 description = This package provides some basic analysis for ELF files.
 tags = intel, files, elf
 script_dir = scripts/Zeek/ELF
-build_command = ./configure --enable-debug --zeek-dist=%(zeek_dist)s && make
+build_command = ./configure --enable-debug && make
 test_command = cd tests && btest


### PR DESCRIPTION
Remove `--zeek-dist` argument from configure command.  

The `--zeek-dist` is not required on Zeek 4.0.3 and Zeek Package Manager 2.7.  It resulted in an error during installation: "<path> does not appear to be a Zeek source tree".  Removal of this argument allowed installation to proceed normally.